### PR TITLE
Performance: optimize fuel trim PW calcs (#756)

### DIFF
--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -210,7 +210,7 @@ void sendcanValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portTy
   fullStatus[0] = currentStatus.secl; //secl is simply a counter that increments each second. Used to track unexpected resets (Which will reset this count to 0)
   fullStatus[1] = currentStatus.status1; //status1 Bitfield, inj1Status(0), inj2Status(1), inj3Status(2), inj4Status(3), DFCOOn(4), boostCutFuel(5), toothLog1Ready(6), toothLog2Ready(7)
   fullStatus[2] = currentStatus.engine; //Engine Status Bitfield, running(0), crank(1), ase(2), warmup(3), tpsaccaen(4), tpsacden(5), mapaccaen(6), mapaccden(7)
-  fullStatus[3] = (byte)(divu100(currentStatus.dwell)); //Dwell in ms * 10
+  fullStatus[3] = (byte)div100(currentStatus.dwell); //Dwell in ms * 10
   fullStatus[4] = lowByte(currentStatus.MAP); //2 bytes for MAP
   fullStatus[5] = highByte(currentStatus.MAP);
   fullStatus[6] = (byte)(currentStatus.IAT + CALIBRATION_TEMPERATURE_OFFSET); //mat

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -899,7 +899,7 @@ uint16_t correctionsDwell(uint16_t dwell)
   uint16_t tempDwell = dwell;
   //Pull battery voltage based dwell correction and apply if needed
   currentStatus.dwellCorrection = table2D_getValue(&dwellVCorrectionTable, currentStatus.battery10);
-  if (currentStatus.dwellCorrection != 100) { tempDwell = divs100(dwell) * currentStatus.dwellCorrection; }
+  if (currentStatus.dwellCorrection != 100) { tempDwell = div100(dwell) * currentStatus.dwellCorrection; }
 
   //Dwell limiter
   uint16_t dwellPerRevolution = tempDwell + (uint16_t)(configPage4.sparkDur * 100); //Spark duration is in mS*10. Multiple it by 100 to get spark duration in uS

--- a/speeduino/crankMaths.ino
+++ b/speeduino/crankMaths.ino
@@ -31,11 +31,7 @@ unsigned long angleToTime(int16_t angle, byte method)
 
     if( (method == CRANKMATH_METHOD_INTERVAL_REV) || (method == CRANKMATH_METHOD_INTERVAL_DEFAULT) )
     {
-      #ifdef USE_LIBDIVIDE
-        returnTime = libdivide::libdivide_u32_do(angle * revolutionTime, &libdiv_u32_360);
-      #else
-        returnTime = ((angle * revolutionTime) / 360);
-      #endif
+        returnTime = div360(angle * revolutionTime);
         //returnTime = angle * (unsigned long)timePerDegree;
     }
     else if (method == CRANKMATH_METHOD_INTERVAL_TOOTH)

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -443,14 +443,18 @@ extern struct table3d8RpmLoad boostTable; //8x8 boost map
 extern struct table3d8RpmLoad vvtTable; //8x8 vvt map
 extern struct table3d8RpmLoad vvt2Table; //8x8 vvt map
 extern struct table3d8RpmLoad wmiTable; //8x8 wmi map
-extern struct table3d6RpmLoad trim1Table; //6x6 Fuel trim 1 map
-extern struct table3d6RpmLoad trim2Table; //6x6 Fuel trim 2 map
-extern struct table3d6RpmLoad trim3Table; //6x6 Fuel trim 3 map
-extern struct table3d6RpmLoad trim4Table; //6x6 Fuel trim 4 map
-extern struct table3d6RpmLoad trim5Table; //6x6 Fuel trim 5 map
-extern struct table3d6RpmLoad trim6Table; //6x6 Fuel trim 6 map
-extern struct table3d6RpmLoad trim7Table; //6x6 Fuel trim 7 map
-extern struct table3d6RpmLoad trim8Table; //6x6 Fuel trim 8 map
+
+typedef table3d6RpmLoad trimTable3d; 
+
+extern trimTable3d trim1Table; //6x6 Fuel trim 1 map
+extern trimTable3d trim2Table; //6x6 Fuel trim 2 map
+extern trimTable3d trim3Table; //6x6 Fuel trim 3 map
+extern trimTable3d trim4Table; //6x6 Fuel trim 4 map
+extern trimTable3d trim5Table; //6x6 Fuel trim 5 map
+extern trimTable3d trim6Table; //6x6 Fuel trim 6 map
+extern trimTable3d trim7Table; //6x6 Fuel trim 7 map
+extern trimTable3d trim8Table; //6x6 Fuel trim 8 map
+
 extern struct table3d4RpmLoad dwellTable; //4x4 Dwell map
 extern struct table2D taeTable; //4 bin TPS Acceleration Enrichment map (2D)
 extern struct table2D maeTable;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -18,14 +18,14 @@ struct table3d8RpmLoad boostTable; ///< 8x8 boost map
 struct table3d8RpmLoad vvtTable; ///< 8x8 vvt map
 struct table3d8RpmLoad vvt2Table; ///< 8x8 vvt2 map
 struct table3d8RpmLoad wmiTable; ///< 8x8 wmi map
-struct table3d6RpmLoad trim1Table; ///< 6x6 Fuel trim 1 map
-struct table3d6RpmLoad trim2Table; ///< 6x6 Fuel trim 2 map
-struct table3d6RpmLoad trim3Table; ///< 6x6 Fuel trim 3 map
-struct table3d6RpmLoad trim4Table; ///< 6x6 Fuel trim 4 map
-struct table3d6RpmLoad trim5Table; ///< 6x6 Fuel trim 5 map
-struct table3d6RpmLoad trim6Table; ///< 6x6 Fuel trim 6 map
-struct table3d6RpmLoad trim7Table; ///< 6x6 Fuel trim 7 map
-struct table3d6RpmLoad trim8Table; ///< 6x6 Fuel trim 8 map
+trimTable3d trim1Table; ///< 6x6 Fuel trim 1 map
+trimTable3d trim2Table; ///< 6x6 Fuel trim 2 map
+trimTable3d trim3Table; ///< 6x6 Fuel trim 3 map
+trimTable3d trim4Table; ///< 6x6 Fuel trim 4 map
+trimTable3d trim5Table; ///< 6x6 Fuel trim 5 map
+trimTable3d trim6Table; ///< 6x6 Fuel trim 6 map
+trimTable3d trim7Table; ///< 6x6 Fuel trim 7 map
+trimTable3d trim8Table; ///< 6x6 Fuel trim 8 map
 struct table3d4RpmLoad dwellTable; ///< 4x4 Dwell map
 struct table2D taeTable; ///< 4 bin TPS Acceleration Enrichment map (2D)
 struct table2D maeTable;

--- a/speeduino/maths.h
+++ b/speeduino/maths.h
@@ -1,17 +1,74 @@
 #ifndef MATH_H
 #define MATH_H
 
-#include "globals.h"
-
 #define USE_LIBDIVIDE
 
 int fastMap1023toX(int, int);
-unsigned long percentage(byte, unsigned long);
-unsigned long halfPercentage(byte, unsigned long);
+unsigned long percentage(uint8_t, unsigned long);
+unsigned long halfPercentage(uint8_t, unsigned long);
 inline long powint(int, unsigned int);
-int32_t divs100(int32_t);
-unsigned long divu100(unsigned long);
-uint32_t divu10(uint32_t);
+
+#ifdef USE_LIBDIVIDE
+#include "src/libdivide/libdivide.h"
+extern struct libdivide::libdivide_u16_t libdiv_u16_100;
+extern struct libdivide::libdivide_s16_t libdiv_s16_100;
+extern struct libdivide::libdivide_u32_t libdiv_u32_100;
+extern struct libdivide::libdivide_s32_t libdiv_s32_100;
+extern struct libdivide::libdivide_u32_t libdiv_u32_360;
+#endif
+
+inline uint8_t div100(uint8_t n) {
+    return n / (uint8_t)100U;
+}
+inline int8_t div100(int8_t n) {
+    return n / (int8_t)100U;
+}
+inline uint16_t div100(uint16_t n) {
+#ifdef USE_LIBDIVIDE    
+    return libdivide::libdivide_u16_do(n, &libdiv_u16_100);
+#else
+    return n / (uint16_t)100U;
+#endif
+}
+inline int16_t div100(int16_t n) {
+#ifdef USE_LIBDIVIDE    
+    return libdivide::libdivide_s16_do(n, &libdiv_s16_100);
+#else
+    return n / (int16_t)100;
+#endif
+}
+inline uint32_t div100(uint32_t n) {
+#ifdef USE_LIBDIVIDE    
+    return libdivide::libdivide_u32_do(n, &libdiv_u32_100);
+#else
+    return n / (uint32_t)100U;
+#endif
+}
+#if defined(__arm__)
+inline int div100(int n) {
+#ifdef USE_LIBDIVIDE    
+    return libdivide::libdivide_s32_do(n, &libdiv_s32_100);
+#else
+    return n / (int)100;
+#endif
+}
+#else
+inline int32_t div100(int32_t n) {
+#ifdef USE_LIBDIVIDE    
+    return libdivide::libdivide_s32_do(n, &libdiv_s32_100);
+#else
+    return n / (int32_t)100;
+#endif
+}
+#endif
+
+inline uint32_t div360(uint32_t n) {
+#ifdef USE_LIBDIVIDE
+    return libdivide::libdivide_u32_do(n, &libdiv_u32_360);
+#else
+    return n / 360U;
+#endif
+}
 
 #define DIV_ROUND_CLOSEST(n, d) ((((n) < 0) ^ ((d) < 0)) ? (((n) - (d)/2)/(d)) : (((n) + (d)/2)/(d)))
 
@@ -20,9 +77,5 @@ uint32_t divu10(uint32_t);
 #define fastMap1023toX(x, out_max) ( ((unsigned long)x * out_max) >> 10)
 //This is a new version that allows for out_min
 #define fastMap10Bit(x, out_min, out_max) ( ( ((unsigned long)x * (out_max-out_min)) >> 10 ) + out_min)
-
-#ifdef USE_LIBDIVIDE
-extern struct libdivide::libdivide_u32_t libdiv_u32_360;
-#endif
 
 #endif

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -89,6 +89,14 @@ void setup()
   initialisationComplete = false; //Tracks whether the initialiseAll() function has run completely
   initialiseAll();
 }
+
+inline uint16_t applyFuelTrimToPW(trimTable3d *pTrimTable, int16_t fuelLoad, int16_t RPM, uint16_t currentPW)
+{
+    unsigned long pw1percent = 100 + get3DTableValue(pTrimTable, fuelLoad, RPM) - OFFSET_FUELTRIM;
+    if (pw1percent != 100) { return div100(pw1percent * currentPW); }
+    return currentPW;
+}
+
 /** Speeduino main loop.
  * 
  * Main loop chores (roughly in  order they are preformed):
@@ -177,7 +185,7 @@ void loop()
     {
       currentStatus.longRPM = getRPM(); //Long RPM is included here
       currentStatus.RPM = currentStatus.longRPM;
-      currentStatus.RPMdiv100 = divu100(currentStatus.RPM);
+      currentStatus.RPMdiv100 = div100(currentStatus.RPM);
       FUEL_PUMP_ON();
       currentStatus.fuelPumpOn = true; //Not sure if this is needed.
     }
@@ -592,11 +600,8 @@ void loop()
           
           if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage6.fuelTrimEnabled > 0) )
             {
-              unsigned long pw1percent = 100 + (byte)get3DTableValue(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw2percent = 100 + (byte)get3DTableValue(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-              
-              if (pw1percent != 100) { currentStatus.PW1 = (pw1percent * currentStatus.PW1) / 100; }
-              if (pw2percent != 100) { currentStatus.PW2 = (pw2percent * currentStatus.PW2) / 100; }
+              currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
+              currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
             }
           else if( (configPage10.stagingEnabled == true) && (currentStatus.PW3 > 0) )
           {
@@ -617,13 +622,9 @@ void loop()
           
           if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage6.fuelTrimEnabled > 0) )
             {
-              unsigned long pw1percent = 100 + (byte)get3DTableValue(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw2percent = 100 + (byte)get3DTableValue(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw3percent = 100 + (byte)get3DTableValue(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-
-              if (pw1percent != 100) { currentStatus.PW1 = (pw1percent * currentStatus.PW1) / 100; }
-              if (pw2percent != 100) { currentStatus.PW2 = (pw2percent * currentStatus.PW2) / 100; }
-              if (pw3percent != 100) { currentStatus.PW3 = (pw3percent * currentStatus.PW3) / 100; }
+              currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
+              currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
+              currentStatus.PW3 = applyFuelTrimToPW(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW3);
             }
           break;
         //4 cylinders
@@ -640,15 +641,10 @@ void loop()
 
             if(configPage6.fuelTrimEnabled > 0)
             {
-              unsigned long pw1percent = 100 + (byte)get3DTableValue(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw2percent = 100 + (byte)get3DTableValue(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw3percent = 100 + (byte)get3DTableValue(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw4percent = 100 + (byte)get3DTableValue(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-
-              if (pw1percent != 100) { currentStatus.PW1 = (pw1percent * currentStatus.PW1) / 100; }
-              if (pw2percent != 100) { currentStatus.PW2 = (pw2percent * currentStatus.PW2) / 100; }
-              if (pw3percent != 100) { currentStatus.PW3 = (pw3percent * currentStatus.PW3) / 100; }
-              if (pw4percent != 100) { currentStatus.PW4 = (pw4percent * currentStatus.PW4) / 100; }
+              currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
+              currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
+              currentStatus.PW3 = applyFuelTrimToPW(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW3);
+              currentStatus.PW4 = applyFuelTrimToPW(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW4);
             }
           }
           else if( (configPage10.stagingEnabled == true) && (currentStatus.PW3 > 0) )
@@ -687,19 +683,12 @@ void loop()
 
               if(configPage6.fuelTrimEnabled > 0)
               {
-                unsigned long pw1percent = 100 + (byte)get3DTableValue(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw2percent = 100 + (byte)get3DTableValue(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw3percent = 100 + (byte)get3DTableValue(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw4percent = 100 + (byte)get3DTableValue(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw5percent = 100 + (byte)get3DTableValue(&trim5Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw6percent = 100 + (byte)get3DTableValue(&trim6Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-
-                if (pw1percent != 100) { currentStatus.PW1 = (pw1percent * currentStatus.PW1) / 100; }
-                if (pw2percent != 100) { currentStatus.PW2 = (pw2percent * currentStatus.PW2) / 100; }
-                if (pw3percent != 100) { currentStatus.PW3 = (pw3percent * currentStatus.PW3) / 100; }
-                if (pw4percent != 100) { currentStatus.PW4 = (pw4percent * currentStatus.PW4) / 100; }
-                if (pw5percent != 100) { currentStatus.PW5 = (pw5percent * currentStatus.PW5) / 100; }
-                if (pw6percent != 100) { currentStatus.PW6 = (pw6percent * currentStatus.PW6) / 100; }
+                currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
+                currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
+                currentStatus.PW3 = applyFuelTrimToPW(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW3);
+                currentStatus.PW4 = applyFuelTrimToPW(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW4);
+                currentStatus.PW5 = applyFuelTrimToPW(&trim5Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW5);
+                currentStatus.PW6 = applyFuelTrimToPW(&trim6Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW6);
               }
             }
           #endif
@@ -726,23 +715,14 @@ void loop()
 
               if(configPage6.fuelTrimEnabled > 0)
               {
-                unsigned long pw1percent = 100 + (byte)get3DTableValue(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw2percent = 100 + (byte)get3DTableValue(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw3percent = 100 + (byte)get3DTableValue(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw4percent = 100 + (byte)get3DTableValue(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw5percent = 100 + (byte)get3DTableValue(&trim5Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw6percent = 100 + (byte)get3DTableValue(&trim6Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw7percent = 100 + (byte)get3DTableValue(&trim7Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-                unsigned long pw8percent = 100 + (byte)get3DTableValue(&trim8Table, currentStatus.fuelLoad, currentStatus.RPM) - OFFSET_FUELTRIM;
-
-                if (pw1percent != 100) { currentStatus.PW1 = (pw1percent * currentStatus.PW1) / 100; }
-                if (pw2percent != 100) { currentStatus.PW2 = (pw2percent * currentStatus.PW2) / 100; }
-                if (pw3percent != 100) { currentStatus.PW3 = (pw3percent * currentStatus.PW3) / 100; }
-                if (pw4percent != 100) { currentStatus.PW4 = (pw4percent * currentStatus.PW4) / 100; }
-                if (pw5percent != 100) { currentStatus.PW5 = (pw5percent * currentStatus.PW5) / 100; }
-                if (pw6percent != 100) { currentStatus.PW6 = (pw6percent * currentStatus.PW6) / 100; }
-                if (pw7percent != 100) { currentStatus.PW7 = (pw7percent * currentStatus.PW7) / 100; }
-                if (pw8percent != 100) { currentStatus.PW8 = (pw8percent * currentStatus.PW8) / 100; }
+                currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
+                currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
+                currentStatus.PW3 = applyFuelTrimToPW(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW3);
+                currentStatus.PW4 = applyFuelTrimToPW(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW4);
+                currentStatus.PW5 = applyFuelTrimToPW(&trim5Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW5);
+                currentStatus.PW6 = applyFuelTrimToPW(&trim6Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW6);
+                currentStatus.PW7 = applyFuelTrimToPW(&trim7Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW7);
+                currentStatus.PW8 = applyFuelTrimToPW(&trim8Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW8);
               }
             }
           #endif

--- a/test/test_misc/tests_maths.cpp
+++ b/test/test_misc/tests_maths.cpp
@@ -20,152 +20,122 @@ void testMaths()
   RUN_TEST(test_maths_div100_S8);
   RUN_TEST(test_maths_div100_S16);
   RUN_TEST(test_maths_div100_S32);
-  RUN_TEST(test_maths_div10_U8);
-  RUN_TEST(test_maths_div10_U16);
-  RUN_TEST(test_maths_div10_U32);
-  
+ 
 }
 
 void test_maths_percent_U8(void)
 {
   uint8_t percentOf = 200;
-  TEST_ASSERT_EQUAL(percentage(50,  percentOf), 100);
-  TEST_ASSERT_EQUAL(percentage(75,  percentOf), 150);
-  TEST_ASSERT_EQUAL(percentage(0,   percentOf), 0);
-  TEST_ASSERT_EQUAL(percentage(100, percentOf), 200);
-  TEST_ASSERT_EQUAL(percentage(125, percentOf), 250);
+  TEST_ASSERT_EQUAL(100, percentage(50,  percentOf));
+  TEST_ASSERT_EQUAL(150, percentage(75,  percentOf));
+  TEST_ASSERT_EQUAL(0, percentage(0,   percentOf));
+  TEST_ASSERT_EQUAL(200, percentage(100, percentOf));
+  TEST_ASSERT_EQUAL(250, percentage(125, percentOf));
 }
 
 void test_maths_percent_U16(void)
 {
   uint16_t percentOf = 20000;
-  TEST_ASSERT_EQUAL(percentage(50,  percentOf), 10000);
-  TEST_ASSERT_EQUAL(percentage(75,  percentOf), 15000);
-  TEST_ASSERT_EQUAL(percentage(0,   percentOf), 0);
-  TEST_ASSERT_EQUAL(percentage(100, percentOf), 20000);
-  TEST_ASSERT_EQUAL(percentage(125, percentOf), 25000);
+  TEST_ASSERT_EQUAL(10000, percentage(50,  percentOf));
+  TEST_ASSERT_EQUAL(15000, percentage(75,  percentOf));
+  TEST_ASSERT_EQUAL(0, percentage(0,   percentOf));
+  TEST_ASSERT_EQUAL(20000, percentage(100, percentOf));
+  TEST_ASSERT_EQUAL(25000, percentage(125, percentOf));
 }
 
 void test_maths_percent_U32(void)
 {
   uint32_t percentOf = 20000000UL;
-  TEST_ASSERT_EQUAL(percentage(50, percentOf), 10000000UL);
-  TEST_ASSERT_EQUAL(percentage(75, percentOf), 15000000UL);
-  TEST_ASSERT_EQUAL(percentage(0, percentOf), 0);
-  TEST_ASSERT_EQUAL(percentage(100, percentOf), 20000000UL);
-  TEST_ASSERT_EQUAL(percentage(125, percentOf), 25000000UL);
+  TEST_ASSERT_EQUAL(10000000UL, percentage(50, percentOf));
+  TEST_ASSERT_EQUAL(15000000UL, percentage(75, percentOf));
+  TEST_ASSERT_EQUAL(0, percentage(0, percentOf));
+  TEST_ASSERT_EQUAL(20000000UL, percentage(100, percentOf));
+  TEST_ASSERT_EQUAL(25000000UL, percentage(125, percentOf));
 }
 
 void test_maths_halfpercent_U8(void)
 {
   uint8_t percentOf = 200;
-  TEST_ASSERT_EQUAL(halfPercentage(50, percentOf), 50);
-  TEST_ASSERT_EQUAL(halfPercentage(75, percentOf), 75);
-  TEST_ASSERT_EQUAL(halfPercentage(0, percentOf), 0);
-  TEST_ASSERT_EQUAL(halfPercentage(100, percentOf), 100);
-  TEST_ASSERT_EQUAL(halfPercentage(125, percentOf), 125);
+  TEST_ASSERT_EQUAL(50, halfPercentage(50, percentOf));
+  TEST_ASSERT_EQUAL(75, halfPercentage(75, percentOf));
+  TEST_ASSERT_EQUAL(0, halfPercentage(0, percentOf));
+  TEST_ASSERT_EQUAL(100, halfPercentage(100, percentOf));
+  TEST_ASSERT_EQUAL(125, halfPercentage(125, percentOf));
 }
 
 void test_maths_halfpercent_U16(void)
 {
   uint16_t percentOf = 20000;
-  TEST_ASSERT_EQUAL(halfPercentage(50, percentOf), 5000);
-  TEST_ASSERT_EQUAL(halfPercentage(75, percentOf), 7500);
-  TEST_ASSERT_EQUAL(halfPercentage(0, percentOf), 0);
-  TEST_ASSERT_EQUAL(halfPercentage(100, percentOf), 10000);
-  TEST_ASSERT_EQUAL(halfPercentage(125, percentOf), 12500);
+  TEST_ASSERT_EQUAL(5000, halfPercentage(50, percentOf));
+  TEST_ASSERT_EQUAL(7500, halfPercentage(75, percentOf));
+  TEST_ASSERT_EQUAL(0, halfPercentage(0, percentOf));
+  TEST_ASSERT_EQUAL(10000, halfPercentage(100, percentOf));
+  TEST_ASSERT_EQUAL(12500, halfPercentage(125, percentOf));
 }
 
 void test_maths_halfpercent_U32(void)
 {
   uint32_t percentOf = 20000000UL;
-  TEST_ASSERT_EQUAL(halfPercentage(50, percentOf), 5000000UL);
-  TEST_ASSERT_EQUAL(halfPercentage(75, percentOf), 7500000UL);
-  TEST_ASSERT_EQUAL(halfPercentage(0, percentOf), 0);
-  TEST_ASSERT_EQUAL(halfPercentage(100, percentOf), 10000000UL);
-  TEST_ASSERT_EQUAL(halfPercentage(125, percentOf), 12500000UL);
+  TEST_ASSERT_EQUAL(5000000UL, halfPercentage(50, percentOf));
+  TEST_ASSERT_EQUAL(7500000UL, halfPercentage(75, percentOf));
+  TEST_ASSERT_EQUAL(0, halfPercentage(0, percentOf));
+  TEST_ASSERT_EQUAL(10000000UL, halfPercentage(100, percentOf));
+  TEST_ASSERT_EQUAL(12500000UL, halfPercentage(125, percentOf));
 }
 
 void test_maths_div100_U8(void)
 {
-  TEST_ASSERT_EQUAL(divu100(100), 1);
-  TEST_ASSERT_EQUAL(divu100(200), 2);
-  TEST_ASSERT_EQUAL(divu100(0), 0);
-  TEST_ASSERT_EQUAL(divu100(50), 0);
-  TEST_ASSERT_EQUAL(divu100(250), 2);
+  TEST_ASSERT_EQUAL_UINT8(1, div100((uint8_t)100U));
+  TEST_ASSERT_EQUAL_UINT8(2, div100((uint8_t)200U));
+  TEST_ASSERT_EQUAL_UINT8(0, div100((uint8_t)0U));
+  TEST_ASSERT_EQUAL_UINT8(0, div100((uint8_t)50U));
+  TEST_ASSERT_EQUAL_UINT8(2, div100((uint8_t)250U));
 }
 
 void test_maths_div100_U16(void)
 {
-  TEST_ASSERT_EQUAL(divu100(10000), 100);
-  TEST_ASSERT_EQUAL(divu100(40000), 400);
+  TEST_ASSERT_EQUAL_UINT16(100, div100((uint16_t)10000U));
+  TEST_ASSERT_EQUAL_UINT16(400, div100((uint16_t)40000U));
 }
 
 void test_maths_div100_U32(void)
 {
-  TEST_ASSERT_EQUAL(divu100(100000000UL), 1000000UL);
-  TEST_ASSERT_EQUAL(divu100(200000000UL), 2000000UL);
+  TEST_ASSERT_EQUAL_UINT32(1000000UL, div100(100000000UL));
+  TEST_ASSERT_EQUAL_UINT32(2000000UL, div100(200000000UL));
 }
 
 void test_maths_div100_S8(void)
 {
   //Check both the signed and unsigned results
-  TEST_ASSERT_EQUAL(divs100(100), 1);
-  TEST_ASSERT_EQUAL(divs100(0), 0);
-  TEST_ASSERT_EQUAL(divs100(50), 0);
+  TEST_ASSERT_EQUAL_INT8(1, div100((int8_t)100));
+  TEST_ASSERT_EQUAL_INT8(0, div100((int8_t)0));
+  TEST_ASSERT_EQUAL_INT8(0, div100((int8_t)50));
 
-  TEST_ASSERT_EQUAL(divs100(-100), -1);
-  TEST_ASSERT_EQUAL(divs100(-50), 0);
-  TEST_ASSERT_EQUAL(divs100(-120), -1);
+  TEST_ASSERT_EQUAL_INT8(-1, div100((int8_t)-100));
+  TEST_ASSERT_EQUAL_INT8(0, div100((int8_t)-50));
+  TEST_ASSERT_EQUAL_INT8(-1, div100((int8_t)-120));
 }
 
 void test_maths_div100_S16(void)
 {
   //Check both the signed and unsigned results
-  TEST_ASSERT_EQUAL(divs100(10000), 100);
-  TEST_ASSERT_EQUAL(divs100(0), 0);
-  TEST_ASSERT_EQUAL(divs100(50), 0);
+  TEST_ASSERT_EQUAL_INT16(100, div100((int16_t)10000));
+  TEST_ASSERT_EQUAL_INT16(0, div100((int16_t)0));
+  TEST_ASSERT_EQUAL_INT16(0, div100((int16_t)50));
 
-  TEST_ASSERT_EQUAL(divs100(-10000), -100);
-  TEST_ASSERT_EQUAL(divs100(-50), 0);
-  TEST_ASSERT_EQUAL(divs100(-120), -1);
+  TEST_ASSERT_EQUAL_INT16(-100, div100((int16_t)-10000));
+  TEST_ASSERT_EQUAL_INT16(0, div100((int16_t)-50));
+  TEST_ASSERT_EQUAL_INT16(-1, div100((int16_t)-120));
 }
 
 void test_maths_div100_S32(void)
 {
   //Check both the signed and unsigned results
-  TEST_ASSERT_EQUAL(divs100(100000000L), 1000000L);
-  TEST_ASSERT_EQUAL(divs100(0), 0);
-  TEST_ASSERT_EQUAL(divs100(50), 0);
+  TEST_ASSERT_EQUAL_INT32(1000000L, div100((int32_t)100000000L));
+  TEST_ASSERT_EQUAL_INT32(0, div100((int32_t)0));
+  TEST_ASSERT_EQUAL_INT32(0, div100((int32_t)50));
 
-  TEST_ASSERT_EQUAL(divs100(-100000000L), -1000000L);
-  TEST_ASSERT_EQUAL(divs100(-50), 0);
-  TEST_ASSERT_EQUAL(divs100(-120), -1);
-}
-
-void test_maths_div10_U8(void)
-{
-  TEST_ASSERT_EQUAL(divu10(100), 10);
-  TEST_ASSERT_EQUAL(divu10(200), 20);
-  TEST_ASSERT_EQUAL(divu10(0), 0);
-  TEST_ASSERT_EQUAL(divu10(50), 5);
-  TEST_ASSERT_EQUAL(divu10(250), 25);
-}
-
-void test_maths_div10_U16(void)
-{
-  TEST_ASSERT_EQUAL(divu10(10000), 1000);
-  TEST_ASSERT_EQUAL(divu10(40000), 4000);
-  TEST_ASSERT_EQUAL(divu10(0), 0);
-  TEST_ASSERT_EQUAL(divu10(50), 5);
-  TEST_ASSERT_EQUAL(divu10(250), 25);
-}
-
-void test_maths_div10_U32(void)
-{
-  TEST_ASSERT_EQUAL(divu10(100000000UL), 10000000UL);
-  TEST_ASSERT_EQUAL(divu10(400000000UL), 40000000UL);
-  TEST_ASSERT_EQUAL(divu10(0), 0);
-  TEST_ASSERT_EQUAL(divu10(50), 5);
-  TEST_ASSERT_EQUAL(divu10(250), 25);
+  TEST_ASSERT_EQUAL_INT32(-1000000L, div100((int32_t)-100000000L));
+  TEST_ASSERT_EQUAL_INT32(0, div100((int32_t)-50));
+  TEST_ASSERT_EQUAL_INT32(-1, div100((int32_t)-120));
 }


### PR DESCRIPTION
* Consistent set of div100 functions

* Add typedef for trimTable3d

* Performance: use div100() function
when applying fuel trim corrections

* Silly ARM compiler!

* Unit test fixes

* Fix tests: expected & actual parameters were swapped

* div100(): add 8-bit overloads for completeness

* Fix unit tests
1. Force call to correct div100() overload
2. Use appropriately typed assertion

* Restore use of USE_LIBDIVIDE preprocessor symbol

* Add div360() - encapsulate libdivide use

* Fix copy/paste issue.